### PR TITLE
Introduce EconomyService for resource handling

### DIFF
--- a/Controllers/economy.service.js
+++ b/Controllers/economy.service.js
@@ -1,0 +1,87 @@
+/* global app */
+(function () {
+    'use strict';
+
+    function ensureState(state) {
+        if (!state) {
+            throw new Error('EconomyService requires a bound state before use.');
+        }
+        return state;
+    }
+
+    function EconomyServiceFactory() {
+        var boundState = null;
+
+        function getState() {
+            return ensureState(boundState);
+        }
+
+        function bindState(state) {
+            boundState = state;
+            return boundState;
+        }
+
+        function incResources(value) {
+            var state = getState();
+            var amount = Number(value) || 0;
+            var availableSpace = state.maxResources - state.resources;
+            if (amount < availableSpace) {
+                state.resources += amount;
+            }
+            else {
+                state.resources = state.maxResources;
+            }
+            return state.resources;
+        }
+
+        function decResources(value) {
+            var state = getState();
+            var amount = Number(value) || 0;
+            if (state.resources >= amount) {
+                state.resources -= amount;
+                return true;
+            }
+            return false;
+        }
+
+        function incGold(value) {
+            var state = getState();
+            var amount = (Number(value) || 0) * (state.goldMulti || 1);
+            var availableSpace = state.maxGold - state.gold;
+            if (amount < availableSpace) {
+                state.gold += amount;
+            }
+            else {
+                state.gold = state.maxGold;
+            }
+            return state.gold;
+        }
+
+        function decGold(value) {
+            var state = getState();
+            var amount = Number(value) || 0;
+            if (state.gold >= amount) {
+                state.gold -= amount;
+                return true;
+            }
+            return false;
+        }
+
+        return {
+            bindState: bindState,
+            incResources: incResources,
+            decResources: decResources,
+            incGold: incGold,
+            decGold: decGold,
+            getState: getState
+        };
+    }
+
+    if (typeof app !== 'undefined' && app.factory) {
+        app.factory('EconomyService', EconomyServiceFactory);
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = EconomyServiceFactory;
+    }
+}());

--- a/Controllers/maincontroller.js
+++ b/Controllers/maincontroller.js
@@ -1,4 +1,4 @@
-app.controller("MainController", function ($scope, $interval, $timeout, $http, $compile, GameConfig) {
+app.controller("MainController", function ($scope, $interval, $timeout, $http, $compile, GameConfig, EconomyService) {
     $scope.dark=false;
     //DEBUG
     $scope.debugging = false;
@@ -28,6 +28,12 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
     $scope.gameLoop = 1000;
     $scope.damageMulti = 1;
     $scope.goldMulti = 1;
+
+    EconomyService.bindState($scope);
+    $scope.incGold = EconomyService.incGold;
+    $scope.decGold = EconomyService.decGold;
+    $scope.incResources = EconomyService.incResources;
+    $scope.decResources = EconomyService.decResources;
 
     //Display Variables
     $scope.version = '1.3';
@@ -430,14 +436,7 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
     $scope.incrRes = function (multi) {
         multi = multi || 1;
         $scope.gameStats.clicks++;
-        if (($scope.resources + multi) < $scope.maxResources) {
-            $scope.resources += (multi);
-
-        }
-        else {
-            $scope.resources = $scope.maxResources;
-        }
-        $scope.resources = $scope.resources;
+        EconomyService.incResources(multi);
     }
 
 
@@ -445,7 +444,7 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
     //function to Incrmeent the current building
 
     $scope.incrBuilding = function (building) {
-        if ($scope.decResources(building.cost)) {
+        if (EconomyService.decResources(building.cost)) {
             building.count++;
             building.cost = Math.ceil(building.cost + Math.pow((building.count + 1), building.multiplier));
             if (building.id == 0 && $scope.buildings[1].enabled == false) {
@@ -576,7 +575,7 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
     }
 
     $scope.incrBlueprint = function (blueprint) {
-        if ($scope.decGold(blueprint.cost)) {
+        if (EconomyService.decGold(blueprint.cost)) {
             blueprint.enabled = false;
             if (blueprint.buildingID > 0) {
                 $scope.buildings[blueprint.buildingID].enabled = true;
@@ -610,7 +609,7 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
         if ($scope.weapons[weapon].count + $scope.weapons[weapon].working < $scope.weapons[weapon].maxCount) {
             if ($scope.resources >= $scope.weapons[weapon].cost) {
                 $('#w'+ weapon).attr('disabled','disabled');
-                $scope.decResources($scope.weapons[weapon].cost);
+                EconomyService.decResources($scope.weapons[weapon].cost);
                 $scope.weapons[weapon].working++;
 
                 if ($scope.panelNumber == 16) {
@@ -635,14 +634,13 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
         if (itemID == -1) {
             if ($scope.potion.count + $scope.potion.working < $scope.potion.maxCount) {
 
-                if ($scope.resources >= $scope.potion.cost) {
+                if (EconomyService.decResources($scope.potion.cost)) {
                     if ($scope.panelNumber == 7) {
                         $scope.nextTutorial();
                     }
                     $('#potionButt').attr('disabled', 'disabled');
-                    $scope.resources -= $scope.potion.cost;
                     $scope.potion.working++;
-                    $scope.createPotion(true, 0);                
+                    $scope.createPotion(true, 0);
                 }
                 else {
                     $scope.showError("You do not have enough Resources.");
@@ -652,9 +650,8 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
         }
         else {
             if ($scope.potions[itemID].count + $scope.potions[itemID].working < $scope.potions[itemID].maxCount) {
-                if ($scope.resources >= $scope.potions[itemID].cost) {
+                if (EconomyService.decResources($scope.potions[itemID].cost)) {
                     $('#a' + itemID).attr('disabled', 'disabled');
-                    $scope.decResources($scope.potions[itemID].cost);
                     $scope.potions[itemID].working++;
                     $scope.createPotions(itemID, true, 0);
                 }
@@ -996,10 +993,9 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
                     break;
                 }
                 case 1: {
-                    if (($scope.potion.count + $scope.potion.working) < $scope.potion.maxCount) {
+                    if (($scope.potion.count + $scope.potion.working) < $scope.potion.maxCount && $scope.heroList[i].progress == "Idle") {
 
-                        if ($scope.resources >= $scope.potion.cost && $scope.heroList[i].progress == "Idle") {
-                            $scope.resources -= $scope.potion.cost;
+                        if (EconomyService.decResources($scope.potion.cost)) {
                             $scope.potion.working++;
                             if (!($scope.heroList[i].academy.id === GameConfig.heroClasses[1].id)) {
                                 $scope.createPotion(false, Math.floor((($scope.heroList[i].level) * .05)*$scope.potion.prodTime), i);
@@ -1012,9 +1008,8 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
                     }
                     for (j = 0; j < $scope.potions.length; j++) {
                         if ($scope.potions[j].enabled && ($scope.potions[j].count + $scope.potions[j].working) < $scope.potions[j].maxCount && $scope.heroList[i].progress == "Idle") {
-                            if ($scope.resources >= $scope.potions[j].cost) {
+                            if (EconomyService.decResources($scope.potions[j].cost)) {
                                 $scope.potions[j].working++;
-                                $scope.resources -= $scope.potions[j].cost;
                                 if (!($scope.heroList[i].academy.id === GameConfig.heroClasses[1].id)) {
                                     $scope.createPotions(j, false, (Math.floor((($scope.heroList[i].level) * .05) * $scope.potions[j].prodTime)), i);
                                 }
@@ -1030,9 +1025,8 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
                 case 2: {
                     for (j = 0; j < $scope.weapons.length; j++) {
                         if ($scope.weapons[j].enabled && ($scope.weapons[j].count + $scope.weapons[j].working) < $scope.weapons[j].maxCount && $scope.heroList[i].progress == "Idle") {
-                            if ($scope.resources >= $scope.weapons[j].cost) {
+                            if (EconomyService.decResources($scope.weapons[j].cost)) {
                                 $scope.weapons[j].working++;
-                                $scope.resources -= $scope.weapons[j].cost;
                                 if (!($scope.heroList[i].academy.id === GameConfig.heroClasses[1].id)) {
                                     $scope.gameStats.weaponsAuto++;
                                     $scope.buyWeapon(j, false, (Math.floor((($scope.heroList[i].level) * .05)*$scope.weapons[j].prodTime)), i);
@@ -2082,46 +2076,6 @@ $(document).ready(function(){
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Safety/ Function ---------------------------------------------------------------------------------------------------------------------------------------------//
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    $scope.incGold = function(value) {
-        if ((value * $scope.goldMulti) < ($scope.maxGold - $scope.gold)) {
-            $scope.gold += value * $scope.goldMulti;
-        }
-        else {
-            $scope.gold = $scope.maxGold;
-        }
-    }
-
-    $scope.decGold = function(value) {
-        if ($scope.gold >= value) {
-            $scope.gold -= value;
-            return true;
-        }
-        else {
-            false;
-        }
-    }
-
-
-    $scope.incResources = function(value) {
-        if (value < ($scope.maxResources - $scope.resources)) {
-            $scope.resources += value;
-        }
-        else {
-            $scope.resources = $scope.maxResources;
-        }
-    }
-
-    $scope.decResources = function(value) {
-        if ($scope.resources >= value) {
-            $scope.resources -= value;
-            return true;
-        }
-        else {
-            false;
-        }
-
-    }
 
     $scope.gainExp = function (hero, amount) {
         hero.experience += amount;

--- a/Controllers/maincontroller.js
+++ b/Controllers/maincontroller.js
@@ -436,7 +436,7 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
     $scope.incrRes = function (multi) {
         multi = multi || 1;
         $scope.gameStats.clicks++;
-        EconomyService.incResources(multi);
+        $scope.incResources(multi);
     }
 
 

--- a/docs/main-controller-domains.md
+++ b/docs/main-controller-domains.md
@@ -1,0 +1,80 @@
+# MainController Domain Inventory
+
+This document inventories the responsibilities packed into `Controllers/maincontroller.js` and maps them to the refactor domains requested earlier. Each section highlights the shared state, the controller routines that manipulate it, and a proposed Angular service/factory that could encapsulate that slice of logic.
+
+## Economy & Building Management
+
+**Shared state**
+- Core resource pools: `resources`, `maxResources`, `gold`, `maxGold`, `incr`, `restAmount`, production multipliers (`damageMulti`, `goldMulti`).
+- Building progression: `buildings`, `blueprints`, `upgrades`, `jobs`, `weapons`, `potions`, tutorial gates (`heroEnabled`, `prodEnabled`, `upgEnabled`, etc.).
+
+**Key routines currently on `$scope`**
+- Resource & currency adjustments: `incrRes`, `incResources`, `decResources`, `incGold`, `decGold`, periodic `work`/`rest` gains.
+- Building and upgrade purchasing: `incrBuilding`, `incrBlueprint`, `activateBlueprint`, `activateDungeon` (building-triggered unlock), upgrade gating inside `incrBuilding` and `gainExp`.
+- Production crafting: `create`, `createPotion`, `createPotions`, `purchaseWeapon`, `buyWeapon`, production queues inside `work`.
+- Progression side-effects: tutorial advances, job unlocks, blueprint enables that are triggered from building counts.
+
+**Suggested service: `EconomyService`**
+- Responsibilities: manage resource pools, enforce purchase requirements, advance buildings/blueprints/upgrades, coordinate production timers, expose calculated availability (e.g., `canAffordBuilding(building)`).
+- Public API candidates: `gather(multi)`, `purchaseBuilding(buildingId)`, `purchaseBlueprint(blueprintId)`, `queueCraft(itemType, itemId, options)`, `adjustGold(delta)`, `adjustResources(delta)`, `unlockNextDungeonIfNeeded()`.
+- Collaboration notes: should emit events/promises when unlock thresholds are crossed so hero/dungeon services can react without the controller hard-wiring cross-domain calls.
+
+## Hero Lifecycle Management
+
+**Shared state**
+- Hero roster and metadata: `heroList`, `tempClass`, `tempHero`, job definitions (`jobs`), class data (`heroClass` via `GameConfig`).
+- Hero progression counters: `successCount`, `lossCount`, `randomEventTimer`, `randomE`, `gameStats` entries tied to hero actions.
+
+**Key routines currently on `$scope`**
+- Roster creation & naming: `addHero`, `addWorker`, `newHeroName`, dialog flows that open on building unlock.
+- Profession & class assignment: `heroProfession`, `heroClassChange`, `confirmClass`, tutorial gating for class/profession.
+- Activity cycles: `rest`, `work`, `gainExp`, `heal` helper, potion activation/cleanup (`activatePotions`, `clearPotions`), gold spending during downtime.
+- Inventory & equipment upkeep: `purchaseWeapon`, `buyWeapon`, weapon durability handling in `heroDamage`, potion crafting queue hooks.
+- Random hero-centric events: `randomEvent` (buffs), `randomE` scheduling, hero stat multipliers applied in combat.
+
+**Suggested service: `HeroRosterService`**
+- Responsibilities: own hero list state, handle hiring/naming, profession/class transitions, leveling/experience gains, rest/work job loops, downtime purchasing behavior, interface to production queues.
+- Public API candidates: `hireHero(options)`, `assignJob(heroId, jobId)`, `queueClassChange(heroId, classId)`, `processRestTick()`, `processWorkTick()`, `applyRandomEvent(eventType)`, `recordBattleOutcome(heroIds, result)`.
+- Collaboration notes: should subscribe to economy events (resource availability, building unlocks) and emit signals for dungeon eligibility or UI updates.
+
+## Dungeon & Battle Flow
+
+**Shared state**
+- Adventure data: `dungeons`, `monsters`, `bosses`, `journeys`, `battles`, `bossBattle`, party selections, encounter timers.
+- Configuration helpers: `monsterList`, `dungeonNames`, `successCount`, `lossCount`, travel pacing (`gameLoop`).
+
+**Key routines currently on `$scope`**
+- Dungeon lifecycle: `activateDungeon`, `attemptDungeon`, `travel`, `journey` setup logic, dungeon selection watchers.
+- Encounter generation: `createMonster`, `createBoss`, random encounter assembly inside `travel`, `monsterFight`, `bossFight`.
+- Battle engine: `startFight`, `takeTurn`, `heroTurn`, `enemyTurn`, `heroDamage`, `monstersAlive`, `monsterFight` loops, loot distribution (`addLoot`), potion toggles (`activatePotions`, `clearPotions`).
+- Outcome handling: success/failure bookkeeping inside `takeTurn`, dungeon advancement (`successCount`/`lossCount`), respawn penalties, tutorial cues.
+
+**Suggested service: `DungeonService`**
+- Responsibilities: maintain dungeon list, orchestrate travel and battle queues, generate encounters, resolve combat rounds, manage loot/XP distribution, enforce dungeon progression rules.
+- Public API candidates: `unlockNextDungeon()`, `startJourney(heroIds, dungeonId)`, `processTravelTick(journeyId)`, `resolveBattleRound(battleId)`, `applyRandomEncounter(journeyId)`, `recordDungeonOutcome(journeyId, result)`.
+- Collaboration notes: should request hero data via `HeroRosterService` (for stats, inventory) and rely on `EconomyService` for rewards/loot crediting.
+
+## UI Notifications & Tutorial Flow
+
+**Shared state**
+- Tutorial panels/log: `panel`, `panelNumber`, `showTutorial`, `panelInfo`, `heroTable`, `bestiary`, etc.
+- Dialog flags: `heroEnabled`, `prodEnabled`, `upgEnabled`, `beastEnabled`, toggles for UI components, modal visibility.
+- Error/logging helpers: `showError`, `debugLog`, watchers on `resources` and `gold` that advance tutorials.
+
+**Key routines currently on `$scope`**
+- Tutorial narration: `nextTutorial`, `skipTut`, `startInfo`, watchers tied to tutorial milestones, `showTutorial` toggles.
+- Dialog orchestration: direct jQuery UI initialization (`#dialog`, `#dialog2`, `#loading`, `#version`, `#confirm`), DOM manipulations like `$('#w' + id)` disabling, manual `document.getElementById` updates.
+- Notifications: `showError`, `showVersion`, `debugLog`, random event slider injection (`randomEvent` timeout).
+
+**Suggested service/directive suite: `NotificationService` + UI Components**
+- Responsibilities: centralize tutorial state machine, surface toast/log messaging, abstract dialog lifecycle behind Angular directives/components, expose observables for UI binding.
+- Public API candidates: `pushMessage(message, options)`, `advanceTutorial(stepId)`, `openDialog(dialogId, data)`, `togglePanel(panelName, flag)`, `emitRandomEvent(eventType)`.
+- Component ideas: `hero-dialog`, `worker-dialog`, `loading-modal`, `version-modal`, `error-banner`, each replacing the jQuery UI bindings with Angular templates/controllers.
+
+## Cross-Domain Touchpoints to untangle during refactor
+
+- Building unlocks trigger hero and dungeon changes (e.g., `incrBuilding` enabling jobs, calling `activateDungeon` and `createMonster`). Services should communicate through events or a shared store instead of direct cross-calls.
+- Random events manipulate combat and economy multipliers—centralize the timer scheduling so both hero ticks and dungeon loops consume updated pacing values.
+- `work`/`rest` intervals currently rely on controller-owned timers. Moving them into services suggests wrapping `$interval` calls within those services and exposing start/stop hooks to the controller.
+- UI updates still rely on raw DOM access; future directives should bind to service observables rather than reading controller state directly.
+

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <script src="Scripts/jquery-ui-1.10.4.min.js"></script>
     <script src="app.js"></script>
     <script src="Controllers/gameConfig.constant.js"></script>
+    <script src="Controllers/economy.service.js"></script>
     <script src="Controllers/maincontroller.js"></script>
     <script src="bootstrap.min.js"></script>    
     <script src="ui-bootstrap-tpls.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "node tests/saveLoad.test.js"
+    "test": "node tests/runAllTests.js"
   }
 }

--- a/tests/economyService.test.js
+++ b/tests/economyService.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('assert');
+const createEconomyService = require('../Controllers/economy.service.js');
+
+(function runEconomyServiceTests() {
+    const economy = createEconomyService();
+    const state = {
+        resources: 10,
+        maxResources: 25,
+        gold: 5,
+        maxGold: 20,
+        goldMulti: 2
+    };
+
+    economy.bindState(state);
+
+    assert.strictEqual(economy.incResources(5), 15, 'resources should increase by the requested amount');
+    assert.strictEqual(state.resources, 15, 'state should be updated by the service');
+
+    economy.incResources(20);
+    assert.strictEqual(state.resources, 25, 'resource gain should clamp to the maximum capacity');
+
+    assert.strictEqual(economy.decResources(5), true, 'spending resources within budget should succeed');
+    assert.strictEqual(state.resources, 20, 'spending resources should reduce the stored amount');
+    assert.strictEqual(economy.decResources(30), false, 'spending more resources than available should fail');
+    assert.strictEqual(state.resources, 20, 'failed spending attempts should leave resources untouched');
+
+    assert.strictEqual(economy.incGold(2), 9, 'gold gains should consider the active multiplier');
+    economy.incGold(20);
+    assert.strictEqual(state.gold, 20, 'gold gains should clamp to the maximum capacity');
+
+    assert.strictEqual(economy.decGold(4), true, 'gold spending within the available amount should succeed');
+    assert.strictEqual(state.gold, 16, 'successful gold spending should reduce stored gold');
+    assert.strictEqual(economy.decGold(50), false, 'gold spending should fail when funds are insufficient');
+    assert.strictEqual(state.gold, 16, 'failed gold spending attempts should not change stored gold');
+
+    console.log('EconomyService tests passed');
+}());

--- a/tests/runAllTests.js
+++ b/tests/runAllTests.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./saveLoad.test.js');
+require('./economyService.test.js');


### PR DESCRIPTION
## Summary
- add an EconomyService that binds to the game state and centralizes resource and gold adjustments
- refactor MainController to delegate gathering, spending, and purchases to the service and register it in the page
- cover the service with unit tests and update the npm test runner to execute all suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f78fd7c4cc8331a2a47c0aa6b392c6