### PR TITLE
Fix model data fetch paths for case-sensitive hosts

### DIFF
--- a/Controllers/maincontroller.js
+++ b/Controllers/maincontroller.js
@@ -221,17 +221,17 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
 
     $scope.heroClass = angular.copy(GameConfig.heroClasses);
 
-    $http.get('Models/heroName.json')
+    $http.get('models/heroName.json')
         .success(function (data) {
             $scope.heroName = data;
         });
 
-    $http.get('Models/monsterList.json')
+    $http.get('models/monsterList.json')
          .success(function (data) {
              $scope.monsterList = data;
          });
 
-    $http.get('Models/dungeons.json')
+    $http.get('models/dungeons.json')
          .success(function (data) {
              $scope.dungeonNames = data;
          });


### PR DESCRIPTION
## Summary
- update the Angular controller to request JSON assets from the lowercase `models/` directory
- audit the repository for other `Models/` references and confirm none remain
- verify the corrected paths succeed when served from a case-sensitive host via an HTTP request

## Testing
- curl -I http://127.0.0.1:8000/models/heroName.json

------
https://chatgpt.com/codex/tasks/task_e_68f80e773ac08331a08462ec4ac131e5