### PR TITLE
feat: add save state service

### DIFF
--- a/src/controllers/maincontroller.js
+++ b/src/controllers/maincontroller.js
@@ -1,6 +1,6 @@
 import app from '../app.js';
 
-app.controller("MainController", function ($scope, $interval, $timeout, $http, $compile, GameConfig, EconomyService) {
+app.controller("MainController", function ($scope, $interval, $timeout, $http, $compile, GameConfig, EconomyService, SaveStateService) {
     $scope.dark=false;
     //DEBUG
     $scope.debugging = false;
@@ -36,6 +36,7 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
     $scope.decGold = EconomyService.decGold;
     $scope.incResources = EconomyService.incResources;
     $scope.decResources = EconomyService.decResources;
+    $scope.pendingIncompatibleSave = false;
 
     //Display Variables
     $scope.version = '1.3';
@@ -255,28 +256,12 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
     //Game Functions (SAVE/LOAD/RESET) ----------------------------------------------------------------------------------------------------------------------------//
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     $scope.reset = function () {
-        //TODO: Add confirm dialog.
-        const raw = localStorage.getItem('data');
-        if (!raw) {
-            $scope.showError("No save data to reset.");
-            return;
-        }
-        let data;
-        try {
-            data = JSON.parse(raw);
-        } catch (error) {
-            $scope.showError("Failed to reset save data: " + error.message);
-            localStorage.removeItem('data');
-            return;
-        }
-        data.saveVersion = "Reset";
-        localStorage.setItem('data', JSON.stringify(data));
-        location.reload();
+        SaveStateService.reset();
     }
 
 
-    $scope.save = function () {
-        let data = {
+    function buildSaveSnapshot() {
+        return {
             resources: $scope.resources,
             maxResources: $scope.maxResources,
             gold: $scope.gold,
@@ -306,22 +291,16 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
             gameStats: $scope.gameStats,
             panelNumber: $scope.panelNumber,
             showTutorial: $scope.showTutorial
-    }
-    localStorage["data"] = JSON.stringify(data);
-    $scope.showError("Game has saved");
+        };
     }
 
-    $scope.loadData = function () {
-        const raw = localStorage.getItem('data');
-        if (!raw) {
-            return;
-        }
-        let data;
-        try {
-            data = JSON.parse(raw);
-        } catch (error) {
-            $scope.showError("Failed to load save data. Clearing corrupted save. Error: " + error.message);
-            localStorage.removeItem('data');
+    $scope.save = function () {
+        const data = buildSaveSnapshot();
+        SaveStateService.save(data);
+    }
+
+    function applySaveState(data) {
+        if (!data) {
             return;
         }
         $scope.resources = data.resources;
@@ -402,38 +381,29 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
             $scope.panelNumber = (data.panelNumber - 1);
             $scope.showTutorial = data.showTutorial;
             $scope.nextTutorial();
-            
+
         }
     }
 
+    $scope.loadData = function () {
+        const data = SaveStateService.loadData();
+        if (!data) {
+            return;
+        }
+        applySaveState(data);
+    }
+
     $scope.load = function () {
-        const raw = localStorage.getItem('data');
-        if (!raw) {
+        const result = SaveStateService.load({
+            currentVersion: $scope.version,
+            forceReset: $scope.forceReset
+        });
+        if (!result || !result.data) {
             return;
         }
-        let test;
-        try {
-            test = JSON.parse(raw);
-        } catch (error) {
-            $scope.showError("Failed to parse save data. Clearing corrupted save. Error: " + error.message);
-            localStorage.removeItem('data');
-            return;
+        if (!result.incompatible) {
+            applySaveState(result.data);
         }
-        if (test) {
-            if (test.saveVersion != $scope.version) {
-                if ($scope.forceReset) {
-                    //localStorage.clear();
-                }
-                else {
-                    $("#loading").dialog("open");
-                }
-
-            }
-            else {
-                $scope.loadData();
-            }
-        }
-
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1128,6 +1098,28 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
         }
     }
 
+    function openLoadingDialog() {
+        if (window.$ && $.fn && $.fn.dialog) {
+            $("#loading").dialog("open");
+            $scope.pendingIncompatibleSave = false;
+        }
+    }
+
+    $scope.$on(SaveStateService.EVENTS.ERROR, function (event, payload) {
+        if (payload && payload.message) {
+            $scope.showError(payload.message);
+        }
+    });
+
+    $scope.$on(SaveStateService.EVENTS.SAVED, function () {
+        $scope.showError("Game has saved");
+    });
+
+    $scope.$on(SaveStateService.EVENTS.INCOMPATIBLE, function () {
+        $scope.pendingIncompatibleSave = true;
+        openLoadingDialog();
+    });
+
     $scope.debugLog = function(value) {
         if ($scope.debugging) {
             console.log(value);
@@ -1263,6 +1255,9 @@ app.controller("MainController", function ($scope, $interval, $timeout, $http, $
 
         }
     });
+        if ($scope.pendingIncompatibleSave) {
+            openLoadingDialog();
+        }
         } else {
             $timeout(initLoading, 50);
         }

--- a/src/controllers/save-state.service.js
+++ b/src/controllers/save-state.service.js
@@ -1,0 +1,6 @@
+import app from '../app.js';
+import SaveStateServiceFactory from '../services/save-state.service.js';
+
+app.factory('SaveStateService', SaveStateServiceFactory);
+
+export default SaveStateServiceFactory;

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import 'angulartics-google-analytics';
 import app from './app.js';
 import './controllers/gameConfig.constant.js';
 import './controllers/economy.service.js';
+import './controllers/save-state.service.js';
 import './controllers/maincontroller.js';
 
 

--- a/src/services/save-state.service.js
+++ b/src/services/save-state.service.js
@@ -1,0 +1,145 @@
+const STORAGE_KEY = 'data';
+const EVENTS = Object.freeze({
+    ERROR: 'SaveState:error',
+    SAVED: 'SaveState:saved',
+    RESET: 'SaveState:reset',
+    INCOMPATIBLE: 'SaveState:incompatible'
+});
+
+function SaveStateServiceFactory($window, $rootScope) {
+    function ensureStorage() {
+        if (!$window || !$window.localStorage) {
+            throw new Error('localStorage is not available.');
+        }
+        return $window.localStorage;
+    }
+
+    function broadcast(eventName, payload) {
+        $rootScope.$broadcast(eventName, payload || {});
+    }
+
+    function readRaw() {
+        const storage = ensureStorage();
+        const raw = storage.getItem(STORAGE_KEY);
+        return typeof raw === 'string' ? raw : null;
+    }
+
+    function writeRaw(serialized) {
+        ensureStorage().setItem(STORAGE_KEY, serialized);
+    }
+
+    function removeRaw() {
+        ensureStorage().removeItem(STORAGE_KEY);
+    }
+
+    function parseSnapshot(raw, messagePrefix, { clearOnError = true } = {}) {
+        if (!raw) {
+            return null;
+        }
+        try {
+            return JSON.parse(raw);
+        }
+        catch (error) {
+            if (clearOnError) {
+                try {
+                    removeRaw();
+                }
+                catch { /* ignore storage removal errors */ }
+            }
+            broadcast(EVENTS.ERROR, {
+                message: `${messagePrefix}${error.message}`,
+                error
+            });
+            return null;
+        }
+    }
+
+    function save(stateSnapshot) {
+        try {
+            const serialized = JSON.stringify(stateSnapshot ?? {});
+            writeRaw(serialized);
+            broadcast(EVENTS.SAVED, { snapshot: stateSnapshot });
+            return true;
+        }
+        catch (error) {
+            broadcast(EVENTS.ERROR, {
+                message: `Failed to save game: ${error.message}`,
+                error
+            });
+            return false;
+        }
+    }
+
+    function loadData() {
+        const raw = readRaw();
+        return parseSnapshot(raw, 'Failed to load save data. Clearing corrupted save. Error: ');
+    }
+
+    function load(options = {}) {
+        const raw = readRaw();
+        const data = parseSnapshot(raw, 'Failed to parse save data. Clearing corrupted save. Error: ');
+        if (!data) {
+            return null;
+        }
+
+        const { currentVersion, forceReset = false } = options;
+        const incompatible = Boolean(currentVersion && data.saveVersion !== currentVersion);
+
+        if (incompatible && !forceReset) {
+            broadcast(EVENTS.INCOMPATIBLE, { snapshot: data });
+        }
+
+        return {
+            data,
+            incompatible,
+            forceReset: Boolean(forceReset)
+        };
+    }
+
+    function reset() {
+        const raw = readRaw();
+        if (!raw) {
+            broadcast(EVENTS.ERROR, { message: 'No save data to reset.' });
+            return false;
+        }
+
+        const data = parseSnapshot(raw, 'Failed to reset save data: ', { clearOnError: true });
+        if (!data) {
+            return false;
+        }
+
+        data.saveVersion = 'Reset';
+
+        try {
+            writeRaw(JSON.stringify(data));
+        }
+        catch (error) {
+            broadcast(EVENTS.ERROR, {
+                message: `Failed to reset save data: ${error.message}`,
+                error
+            });
+            return false;
+        }
+
+        broadcast(EVENTS.RESET, { snapshot: data });
+        if ($window && $window.location && typeof $window.location.reload === 'function') {
+            try {
+                $window.location.reload();
+            }
+            catch { /* ignore reload errors in tests */ }
+        }
+        return true;
+    }
+
+    return {
+        EVENTS,
+        save,
+        load,
+        loadData,
+        reset
+    };
+}
+
+SaveStateServiceFactory.$inject = ['$window', '$rootScope'];
+
+export default SaveStateServiceFactory;

--- a/tests/mainController.saveState.integration.spec.js
+++ b/tests/mainController.saveState.integration.spec.js
@@ -1,0 +1,342 @@
+import { before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import GameConfig from '../src/constants/gameConfig.data.js';
+import { bootstrapAngular, createInjector } from './utils/angular.js';
+
+function createStorageStub() {
+    const store = new Map();
+    return {
+        getItem(key) {
+            return store.has(key) ? store.get(key) : null;
+        },
+        setItem(key, value) {
+            store.set(key, String(value));
+        },
+        removeItem(key) {
+            store.delete(key);
+        },
+        clear() {
+            store.clear();
+        },
+        _store: store
+    };
+}
+
+function createJQueryStub() {
+    const propStore = new Map();
+    const dialogCalls = [];
+
+    function cloneValue(value) {
+        if (Array.isArray(value)) {
+            return value.map(cloneValue);
+        }
+        if (value && typeof value === 'object') {
+            const result = {};
+            for (const [key, inner] of Object.entries(value)) {
+                result[key] = cloneValue(inner);
+            }
+            return result;
+        }
+        return value;
+    }
+
+    function stub(selector) {
+        if (selector === global.document || selector === (global.window && global.window.document)) {
+            return {
+                delegate() { return this; },
+                find() { return this; },
+                on() { return this; },
+                off() { return this; }
+            };
+        }
+
+        const element = {
+            dialog(...args) {
+                dialogCalls.push({ selector, args });
+                return element;
+            },
+            prop(name, value) {
+                const key = `${selector}:${name}`;
+                if (value === undefined) {
+                    return propStore.has(key) ? propStore.get(key) : false;
+                }
+                propStore.set(key, value);
+                return element;
+            },
+            val(value) {
+                const key = `${selector}:val`;
+                if (value === undefined) {
+                    return propStore.get(key) ?? '';
+                }
+                propStore.set(key, value);
+                return element;
+            },
+            hide() { return element; },
+            show() { return element; },
+            remove() { return element; },
+            append() { return element; },
+            find() { return element; },
+            eq() { return element; },
+            trigger() { return element; },
+            on() { return element; },
+            off() { return element; }
+        };
+
+        return element;
+    }
+
+    stub.fn = { dialog() {} };
+    stub.ui = { keyCode: { ENTER: 13 } };
+    stub.extend = function extend(deep, target, ...sources) {
+        if (typeof deep !== 'boolean') {
+            sources = [target, ...sources];
+            target = deep;
+            deep = false;
+        }
+        const output = target || {};
+        for (const source of sources) {
+            if (!source) continue;
+            for (const [key, value] of Object.entries(source)) {
+                if (deep && value && typeof value === 'object') {
+                    output[key] = extend(true, Array.isArray(value) ? [] : {}, value);
+                } else {
+                    output[key] = value;
+                }
+            }
+        }
+        return output;
+    };
+    stub.__dialogCalls = dialogCalls;
+    stub.__propStore = propStore;
+    stub.__clone = cloneValue;
+    return stub;
+}
+
+function createHttpStub() {
+    return {
+        get() {
+            return {
+                then(resolve, reject) {
+                    if (typeof resolve === 'function') {
+                        resolve({ data: [] });
+                    }
+                    if (typeof reject === 'function') {
+                        // noop
+                    }
+                    return this;
+                },
+                catch() {
+                    return this;
+                }
+            };
+        }
+    };
+}
+
+function createTimeoutStub() {
+    const queue = [];
+    function $timeout(fn) {
+        queue.push(fn);
+        return { $$timeoutId: queue.length };
+    }
+    $timeout.flush = () => {
+        while (queue.length) {
+            const task = queue.shift();
+            if (typeof task === 'function') {
+                task();
+            }
+        }
+    };
+    $timeout.cancel = () => {};
+    return $timeout;
+}
+
+function buildSnapshotFromScope(scope, heroTable = false) {
+    return JSON.parse(JSON.stringify({
+        resources: scope.resources,
+        maxResources: scope.maxResources,
+        gold: scope.gold,
+        maxGold: scope.maxGold,
+        incr: scope.incr,
+        restAmount: scope.restAmount,
+        buildings: scope.buildings,
+        blueprints: scope.blueprints,
+        heroList: scope.heroList,
+        weapons: scope.weapons,
+        potions: scope.potions,
+        upgrades: scope.upgrades,
+        journeys: scope.journeys,
+        bossBattle: scope.bossBattle,
+        battles: scope.battles,
+        dungeons: scope.dungeons,
+        jobs: scope.jobs,
+        potion: scope.potion,
+        saveVersion: scope.version,
+        monsters: scope.monsters,
+        bosses: scope.bosses,
+        bestiary: scope.bestiary,
+        heroTable,
+        success: scope.successCount.amount,
+        losses: scope.lossCount.amount,
+        party: scope.party,
+        gameStats: scope.gameStats,
+        panelNumber: scope.panelNumber,
+        showTutorial: scope.showTutorial
+    }));
+}
+
+describe('MainController save state integration', () => {
+    let injector;
+    let SaveStateService;
+    let $controller;
+    let $rootScope;
+    let jqueryStub;
+
+    before(async () => {
+        jqueryStub = createJQueryStub();
+        const storage = createStorageStub();
+
+        if (!global.window) {
+            global.window = {};
+        }
+        global.window.localStorage = storage;
+        global.window.location = global.window.location || {};
+        global.window.location.reload = () => {};
+        global.window.$ = jqueryStub;
+        global.window.jQuery = jqueryStub;
+        global.localStorage = storage;
+        global.$ = jqueryStub;
+        global.jQuery = jqueryStub;
+        if (global.document && !global.document.getElementById) {
+            global.document.getElementById = () => ({ innerHTML: '' });
+        }
+
+        await bootstrapAngular({
+            modules: [
+                'src/controllers/gameConfig.constant.js',
+                'src/controllers/economy.service.js',
+                'src/controllers/save-state.service.js',
+                'src/controllers/maincontroller.js'
+            ]
+        });
+        injector = createInjector();
+        SaveStateService = injector.get('SaveStateService');
+        $controller = injector.get('$controller');
+        $rootScope = injector.get('$rootScope');
+    });
+
+    beforeEach(() => {
+        jqueryStub.__dialogCalls.length = 0;
+        jqueryStub.__propStore.clear();
+    });
+
+    it('delegates save snapshots to SaveStateService using the legacy format', () => {
+        const $scope = $rootScope.$new();
+        const timeout = createTimeoutStub();
+        const http = createHttpStub();
+
+        const savedSnapshots = [];
+        const originalSave = SaveStateService.save;
+        SaveStateService.save = (snapshot) => {
+            savedSnapshots.push(snapshot);
+            return true;
+        };
+
+        $controller('MainController', {
+            $scope,
+            $http: http,
+            $timeout: timeout
+        });
+
+        $scope.save();
+
+        assert.strictEqual(savedSnapshots.length, 1);
+        const snapshot = savedSnapshots[0];
+        const expected = buildSnapshotFromScope($scope, jqueryStub('#showOld').prop('checked'));
+        assert.deepStrictEqual(snapshot, expected);
+
+        SaveStateService.save = originalSave;
+    });
+
+    it('loads persisted data through SaveStateService.load()', () => {
+        const $scope = $rootScope.$new();
+        const timeout = createTimeoutStub();
+        const http = createHttpStub();
+
+        $controller('MainController', {
+            $scope,
+            $http: http,
+            $timeout: timeout
+        });
+
+        const snapshot = buildSnapshotFromScope($scope, true);
+        snapshot.resources = 77;
+        snapshot.gold = 33;
+        snapshot.maxResources = 150;
+        snapshot.maxGold = 120;
+        snapshot.buildings[0].count = 5;
+        snapshot.blueprints[0].enabled = true;
+        snapshot.upgrades[0].enabled = false;
+        snapshot.jobs[0].enabled = false;
+        snapshot.potions = snapshot.potions.map((potion) => ({ ...potion, enabled: true }));
+        snapshot.success = 9;
+        snapshot.losses = 2;
+        snapshot.panelNumber = 4;
+        snapshot.showTutorial = false;
+        snapshot.gameStats = { ...snapshot.gameStats, clicks: 42 };
+        snapshot.heroList = [
+            {
+                name: 'Hero',
+                academy: { id: GameConfig.heroClasses[0].id },
+                job: { current: 1 },
+                autoAdventure: true
+            }
+        ];
+
+        const loadCalls = [];
+        const originalLoad = SaveStateService.load;
+        const originalLoadData = SaveStateService.loadData;
+        SaveStateService.load = (options) => {
+            loadCalls.push(options);
+            return { data: snapshot, incompatible: false, forceReset: Boolean(options && options.forceReset) };
+        };
+        SaveStateService.loadData = () => snapshot;
+
+        timeout.flush();
+
+        assert.strictEqual(loadCalls.length, 1);
+        assert.deepStrictEqual(loadCalls[0], { currentVersion: $scope.version, forceReset: $scope.forceReset });
+        assert.strictEqual($scope.resources, snapshot.resources);
+        assert.strictEqual($scope.gold, snapshot.gold);
+        assert.strictEqual($scope.maxResources, snapshot.maxResources);
+        assert.strictEqual($scope.maxGold, snapshot.maxGold);
+        assert.strictEqual($scope.buildings[0].count, snapshot.buildings[0].count);
+        assert.strictEqual($scope.blueprints[0].enabled, true);
+        assert.strictEqual($scope.jobs[0].enabled, false);
+        assert.strictEqual($scope.successCount.amount, snapshot.success);
+        assert.strictEqual($scope.lossCount.amount, snapshot.losses);
+        assert.strictEqual(jqueryStub('#showOld').prop('checked'), true);
+
+        SaveStateService.load = originalLoad;
+        SaveStateService.loadData = originalLoadData;
+    });
+
+    it('opens the loading dialog when SaveStateService reports an incompatible save', () => {
+        const $scope = $rootScope.$new();
+        const timeout = createTimeoutStub();
+        const http = createHttpStub();
+
+        $controller('MainController', {
+            $scope,
+            $http: http,
+            $timeout: timeout
+        });
+
+        jqueryStub.__dialogCalls.length = 0;
+        $rootScope.$broadcast(SaveStateService.EVENTS.INCOMPATIBLE, { snapshot: {} });
+
+        const opened = jqueryStub.__dialogCalls.some((call) => call.selector === '#loading' && call.args[0] === 'open');
+        assert.ok(opened, 'expected the loading dialog to open');
+        assert.strictEqual($scope.pendingIncompatibleSave, false);
+    });
+});

--- a/tests/saveLoad.spec.js
+++ b/tests/saveLoad.spec.js
@@ -1,168 +1,138 @@
-import { describe, it } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import GameConfig from '../src/constants/gameConfig.data.js';
+import SaveStateServiceFactory from '../src/services/save-state.service.js';
 
-describe('save/load routines', () => {
-    function clone(value) {
-        return JSON.parse(JSON.stringify(value));
+function createHarness(initialValue) {
+    const store = new Map();
+    if (initialValue !== undefined) {
+        store.set('data', initialValue);
     }
 
-    function createScope() {
-        const heroClasses = clone(GameConfig.heroClasses);
-        return {
-            version: '1.3',
-            resources: 0,
-            maxResources: 25,
-            gold: 0,
-            maxGold: 0,
-            incr: 1,
-            restAmount: 2,
-            buildings: clone(GameConfig.buildings),
-            blueprints: clone(GameConfig.blueprints),
-            weapons: clone(GameConfig.weapons),
-            potions: clone(GameConfig.potions),
-            heroClass: heroClasses,
-            heroList: [],
-            upgrades: [],
-            journeys: [],
-            bossBattle: [],
-            battles: [],
-            dungeons: [],
-            jobs: [
-                { id: 0, name: 'Gather', current: 0, limit: 100, enabled: true },
-                { id: 1, name: 'Apothecary', current: 0, limit: 1, enabled: false },
-                { id: 2, name: 'Smith', current: 0, limit: 1, enabled: false }
-            ],
-            potion: {
-                id: -1,
-                name: 'Healing Herbs',
-                healing: 20,
-                count: 0,
-                maxCount: 5,
-                cost: 10,
-                prodTime: 5,
-                sellPrice: 1,
-                working: 0
-            },
-            monsters: [],
-            bosses: [],
-            bestiary: false,
-            successCount: { amount: 3 },
-            lossCount: { amount: 1 },
-            party: [],
-            gameStats: {
-                battles: 0,
-                wins: 0,
-                losses: 0,
-                weaponsAuto: 0,
-                weaponsManual: [],
-                buffs: 0,
-                clicks: 0
-            },
-            panelNumber: 0,
-            showTutorial: true
-        };
-    }
+    const localStorage = {
+        getItem(key) {
+            return store.has(key) ? store.get(key) : null;
+        },
+        setItem(key, value) {
+            store.set(key, String(value));
+        },
+        removeItem(key) {
+            store.delete(key);
+        }
+    };
 
-    function save(scope) {
-        return JSON.parse(JSON.stringify({
-            resources: scope.resources,
-            maxResources: scope.maxResources,
-            gold: scope.gold,
-            maxGold: scope.maxGold,
-            incr: scope.incr,
-            restAmount: scope.restAmount,
-            buildings: scope.buildings,
-            blueprints: scope.blueprints,
-            heroList: scope.heroList,
-            weapons: scope.weapons,
-            potions: scope.potions,
-            upgrades: scope.upgrades,
-            dungeons: scope.dungeons,
-            monsters: scope.monsters,
-            bosses: scope.bosses,
-            successCount: scope.successCount,
-            lossCount: scope.lossCount,
-            panelNumber: scope.panelNumber,
-            showTutorial: scope.showTutorial,
-            jobs: scope.jobs,
-            potion: scope.potion,
-            gameStats: scope.gameStats
-        }));
-    }
+    const reloadCalls = [];
+    const $window = {
+        localStorage,
+        location: {
+            reload() {
+                reloadCalls.push(Date.now());
+            }
+        }
+    };
 
-    function load(scope, saveState) {
-        scope.resources = saveState.resources;
-        scope.maxResources = saveState.maxResources;
-        scope.gold = saveState.gold;
-        scope.maxGold = saveState.maxGold;
-        scope.incr = saveState.incr;
-        scope.restAmount = saveState.restAmount;
-        scope.buildings = saveState.buildings;
-        scope.blueprints = saveState.blueprints;
-        scope.heroList = saveState.heroList;
-        scope.weapons = saveState.weapons;
-        scope.potions = saveState.potions;
-        scope.upgrades = saveState.upgrades;
-        scope.dungeons = saveState.dungeons;
-        scope.monsters = saveState.monsters;
-        scope.bosses = saveState.bosses;
-        scope.successCount = saveState.successCount;
-        scope.lossCount = saveState.lossCount;
-        scope.panelNumber = saveState.panelNumber;
-        scope.showTutorial = saveState.showTutorial;
-        scope.jobs = saveState.jobs;
-        scope.potion = saveState.potion;
-        scope.gameStats = saveState.gameStats;
-        return scope;
-    }
+    const events = [];
+    const $rootScope = {
+        $broadcast(event, payload) {
+            events.push({ event, payload });
+        }
+    };
 
-    it('restores a saved scope snapshot without mutating the source data', () => {
-        const scope = createScope();
-        scope.resources = 100;
-        scope.maxResources = 100;
-        scope.gold = 50;
-        scope.maxGold = 150;
-        scope.incr = 10;
-        scope.restAmount = 5;
-        scope.upgrades = [
-            { id: 0, name: 'Upgrade 1', price: 10, enabled: true },
-            { id: 1, name: 'Upgrade 2', price: 20, enabled: false }
-        ];
-        scope.dungeons = [
-            { id: 0, name: 'Dungeon 1', level: 1, steps: 10, encounterRate: 50 },
-            { id: 1, name: 'Dungeon 2', level: 2, steps: 20, encounterRate: 30 }
-        ];
-        scope.monsters = [
-            { id: 0, name: 'Slime', value: 10, minDamage: 1, maxDamage: 3, health: 20 },
-            { id: 1, name: 'Goblin', value: 20, minDamage: 2, maxDamage: 5, health: 30 }
-        ];
-        scope.bosses = [
-            { id: 0, name: 'Dragon', minDamage: 10, maxDamage: 20, health: 100 },
-            { id: 1, name: 'Lich', minDamage: 15, maxDamage: 25, health: 120 }
-        ];
+    const service = SaveStateServiceFactory($window, $rootScope);
 
-        const saveState = save(scope);
-        const loadedScope = load(createScope(), saveState);
+    return { service, store, events, reloadCalls, localStorage };
+}
 
-        assert.deepStrictEqual(loadedScope.resources, scope.resources, 'resources should match after load');
-        assert.deepStrictEqual(loadedScope.maxResources, scope.maxResources, 'max resources should match after load');
-        assert.deepStrictEqual(loadedScope.gold, scope.gold, 'gold should match after load');
-        assert.deepStrictEqual(loadedScope.maxGold, scope.maxGold, 'max gold should match after load');
-        assert.deepStrictEqual(loadedScope.incr, scope.incr, 'increment should match after load');
-        assert.deepStrictEqual(loadedScope.restAmount, scope.restAmount, 'rest amount should match after load');
-        assert.deepStrictEqual(loadedScope.upgrades, scope.upgrades, 'upgrades should match after load');
-        assert.deepStrictEqual(loadedScope.dungeons, scope.dungeons, 'dungeons should match after load');
-        assert.deepStrictEqual(loadedScope.monsters, scope.monsters, 'monsters should match after load');
-        assert.deepStrictEqual(loadedScope.bosses, scope.bosses, 'bosses should match after load');
-        assert.deepStrictEqual(loadedScope.successCount, scope.successCount, 'success count should match after load');
-        assert.deepStrictEqual(loadedScope.lossCount, scope.lossCount, 'loss count should match after load');
-        assert.deepStrictEqual(loadedScope.panelNumber, scope.panelNumber, 'panel number should match after load');
-        assert.deepStrictEqual(loadedScope.showTutorial, scope.showTutorial, 'show tutorial flag should match after load');
-        assert.deepStrictEqual(loadedScope.jobs, scope.jobs, 'jobs should match after load');
-        assert.deepStrictEqual(loadedScope.potion, scope.potion, 'potion should match after load');
-        assert.deepStrictEqual(loadedScope.gameStats, scope.gameStats, 'game stats should match after load');
+describe('SaveStateService', () => {
+    let harness;
 
-        assert.notStrictEqual(saveState, scope, 'the saved snapshot should be a copy');
+    beforeEach(() => {
+        harness = createHarness();
+    });
+
+    it('persists snapshots and returns them via loadData()', () => {
+        const snapshot = { version: '1.3', resources: 42 };
+
+        assert.strictEqual(harness.service.save(snapshot), true);
+        assert.strictEqual(harness.store.get('data'), JSON.stringify(snapshot));
+
+        const loaded = harness.service.loadData();
+        assert.deepStrictEqual(loaded, snapshot);
+        assert.notStrictEqual(loaded, snapshot, 'loadData should return a new object');
+
+        const savedEvent = harness.events.find((evt) => evt.event === harness.service.EVENTS.SAVED);
+        assert.ok(savedEvent, 'expected a saved event to be emitted');
+    });
+
+    it('removes corrupted saves and reports an error when loadData() fails', () => {
+        harness.localStorage.setItem('data', '{');
+
+        const loaded = harness.service.loadData();
+        assert.strictEqual(loaded, null);
+        assert.strictEqual(harness.store.has('data'), false);
+
+        const errorEvent = harness.events.find((evt) => evt.event === harness.service.EVENTS.ERROR);
+        assert.ok(errorEvent, 'expected an error event');
+        assert.match(errorEvent.payload.message, /^Failed to load save data\. Clearing corrupted save\./u);
+    });
+
+    it('removes corrupted saves and reports an error when load() fails to parse', () => {
+        harness.localStorage.setItem('data', 'not-json');
+
+        const loaded = harness.service.load();
+        assert.strictEqual(loaded, null);
+        assert.strictEqual(harness.store.has('data'), false);
+
+        const errorEvent = harness.events.find((evt) => evt.event === harness.service.EVENTS.ERROR);
+        assert.ok(errorEvent, 'expected an error event');
+        assert.match(errorEvent.payload.message, /^Failed to parse save data\. Clearing corrupted save\./u);
+    });
+
+    it('broadcasts an incompatible event when versions do not match', () => {
+        const payload = JSON.stringify({ saveVersion: '1.2', foo: 'bar' });
+        harness = createHarness(payload);
+
+        const result = harness.service.load({ currentVersion: '1.3' });
+        assert.ok(result);
+        assert.strictEqual(result.incompatible, true);
+        assert.strictEqual(result.forceReset, false);
+        assert.deepStrictEqual(result.data.saveVersion, '1.2');
+
+        const incompatible = harness.events.find((evt) => evt.event === harness.service.EVENTS.INCOMPATIBLE);
+        assert.ok(incompatible, 'expected incompatible event');
+        assert.deepStrictEqual(incompatible.payload.snapshot.saveVersion, '1.2');
+
+        const withoutEvent = createHarness(payload);
+        const secondResult = withoutEvent.service.load({ currentVersion: '1.3', forceReset: true });
+        assert.ok(secondResult);
+        assert.strictEqual(secondResult.incompatible, true);
+        assert.strictEqual(secondResult.forceReset, true);
+        const triggered = withoutEvent.events.find((evt) => evt.event === withoutEvent.service.EVENTS.INCOMPATIBLE);
+        assert.strictEqual(triggered, undefined, 'forceReset should suppress incompatible events');
+    });
+
+    it('resets save data and reloads the location', () => {
+        const initial = JSON.stringify({ saveVersion: '1.3', resources: 5 });
+        harness = createHarness(initial);
+
+        const didReset = harness.service.reset();
+        assert.strictEqual(didReset, true);
+
+        const stored = harness.store.get('data');
+        assert.ok(stored);
+        const parsed = JSON.parse(stored);
+        assert.strictEqual(parsed.saveVersion, 'Reset');
+
+        const resetEvent = harness.events.find((evt) => evt.event === harness.service.EVENTS.RESET);
+        assert.ok(resetEvent, 'expected reset event to be emitted');
+        assert.strictEqual(harness.reloadCalls.length, 1);
+    });
+
+    it('reports an error when reset() is invoked without save data', () => {
+        const didReset = harness.service.reset();
+        assert.strictEqual(didReset, false);
+
+        const errorEvent = harness.events.find((evt) => evt.event === harness.service.EVENTS.ERROR);
+        assert.ok(errorEvent, 'expected an error event');
+        assert.strictEqual(errorEvent.payload.message, 'No save data to reset.');
     });
 });


### PR DESCRIPTION
## Summary
- extract persistent save/reset logic into a dedicated SaveStateService with event broadcasting
- integrate MainController with the new service and trigger dialogs via save state events
- add unit and integration coverage for save persistence and controller/service coordination

## Testing
- `npm test` *(fails: missing c8/bin/c8.js in this environment)*
- `node --test tests/saveLoad.spec.js tests/economyService.spec.js tests/mainController.saveState.integration.spec.js` *(fails: angular.min.js not available in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_69040faf322c8331b8bb76d4b0a97986