### PR TITLE
Add status effects system and improve combat/hero mechanics

### DIFF
--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -55,6 +55,14 @@ export const MAX_GAME_LOOP_MS = 5000;
 export const SAVE_INTERVAL_MS = 30_000;
 export const RANDOM_EVENT_BASE_DELAY_MS = 600_000; // 10 minutes base + up to 10 min variance
 
+// Hero automation
+export const HERO_AUTO_HEAL_THRESHOLD = 0.5; // use a health potion when currHealth drops below this fraction of max HP
+
+// Status effects
+export const STATUS_POISON_TICK_PERCENT = 5;     // % of max HP dealt as damage per poison tick
+export const STATUS_STUN_SKIP_CHANCE = 1.0;       // 1.0 = 100%: stun always skips the entity's turn
+export const STATUS_ARMOR_BREAK_MULTIPLIER = 0.5; // +50% damage taken while armor is broken
+
 // Dungeon generation
 export const MONSTERS_PER_BATCH = 3;
 export const MONSTER_HEALTH_MULTIPLIER = 5;

--- a/src/services/combat.service.ts
+++ b/src/services/combat.service.ts
@@ -18,7 +18,6 @@ import {
   POTION_GOOD_HEALTH,
   POTION_GREAT_HEALTH,
   BUILDING_TENT,
-  STATUS_POISON_TICK_PERCENT,
   STATUS_STUN_SKIP_CHANCE,
   STATUS_ARMOR_BREAK_MULTIPLIER,
   HERO_AUTO_HEAL_THRESHOLD,
@@ -155,22 +154,44 @@ function CombatServiceFactory(
 
   /**
    * Applies poison/burn damage and decrements all effect durations by 1.
-   * Effects that reach 0 duration are removed.
+   * Effects are applied based on the current duration (before decrement), so a
+   * duration:1 effect fires once and is then removed.
+   * Supports both heroes (currHealth + health as max HP) and monsters that only
+   * expose health (and optional maxHealth) by:
+   *  - scaling damage off maxHealth ?? health ?? currHealth
+   *  - subtracting from currHealth when present, otherwise from health
    * Returns the total tick damage applied (for callers that need to track HP changes).
    */
-  function processStatusTick(entity: { currHealth?: number; health?: number; statusEffects?: StatusEffect[] }): number {
+  function processStatusTick(entity: {
+    currHealth?: number;
+    health?: number;
+    maxHealth?: number;
+    statusEffects?: StatusEffect[];
+  }): number {
     if (!entity.statusEffects || entity.statusEffects.length === 0) return 0;
     let tickDamage = 0;
-    entity.statusEffects = entity.statusEffects
-      .map((e) => ({ ...e, duration: e.duration - 1 }))
-      .filter((e) => e.duration >= 0);
+
+    // 1) Apply tick effects based on the current duration (duration > 0).
     for (const e of entity.statusEffects) {
-      if ((e.type === 'poison' || e.type === 'burn') && entity.health !== undefined && entity.currHealth !== undefined) {
-        const dmg = Math.ceil((entity.health * e.magnitude) / 100);
+      if (e.duration > 0 && (e.type === 'poison' || e.type === 'burn')) {
+        const baseHealth = entity.maxHealth ?? entity.health ?? entity.currHealth ?? 0;
+        if (baseHealth <= 0) continue;
+        const dmg = Math.ceil((baseHealth * e.magnitude) / 100);
+        if (dmg <= 0) continue;
         tickDamage += dmg;
-        entity.currHealth = Math.max(0, entity.currHealth - dmg);
+        if (entity.currHealth !== undefined) {
+          entity.currHealth = Math.max(0, entity.currHealth - dmg);
+        } else if (entity.health !== undefined) {
+          entity.health = Math.max(0, entity.health - dmg);
+        }
       }
     }
+
+    // 2) Decrement durations and remove any effects that have expired (duration <= 0).
+    entity.statusEffects = entity.statusEffects
+      .map((e) => ({ ...e, duration: e.duration - 1 }))
+      .filter((e) => e.duration > 0);
+
     return tickDamage;
   }
 
@@ -225,7 +246,7 @@ function CombatServiceFactory(
       }
     }
 
-    // Distribute cumulative hero damage sequentially through enemies.
+    // Focus-fire: cumulative hero damage hits the first living enemy.
     // armorBreakMultiplier is applied per-enemy target so a broken-armored enemy
     // takes proportionally more damage from the hero's share.
     const tempDead: Monster[] = [];

--- a/src/services/combat.service.ts
+++ b/src/services/combat.service.ts
@@ -18,9 +18,13 @@ import {
   POTION_GOOD_HEALTH,
   POTION_GREAT_HEALTH,
   BUILDING_TENT,
+  STATUS_POISON_TICK_PERCENT,
+  STATUS_STUN_SKIP_CHANCE,
+  STATUS_ARMOR_BREAK_MULTIPLIER,
+  HERO_AUTO_HEAL_THRESHOLD,
 } from '../constants/gameConstants.ts';
 import type { AppStore } from '../store/index.ts';
-import type { Hero, Monster, GameConfig } from '../types/index.ts';
+import type { Hero, Monster, GameConfig, StatusEffect } from '../types/index.ts';
 
 // suppress unused-import warnings on re-exported action creators
 void replaceHeroes;
@@ -83,7 +87,7 @@ function CombatServiceFactory(
   }
 
   function clearPotions(hero: Hero): void {
-    for (let i = 1; i < hero.equip.potions.length; i++) {
+    for (let i = 0; i < hero.equip.potions.length; i++) {
       if (hero.equip.potions[i].active) {
         hero.equip.potions[i].count--;
       }
@@ -136,11 +140,82 @@ function CombatServiceFactory(
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 
+  // ─── Status Effect Helpers ─────────────────────────────────────────────
+
+  /**
+   * Returns true if the entity has an active stun effect (duration > 0).
+   * Uses STATUS_STUN_SKIP_CHANCE so future designs can make stun probabilistic.
+   */
+  function isStunned(entity: { statusEffects?: StatusEffect[] }): boolean {
+    if (!entity.statusEffects) return false;
+    return entity.statusEffects.some(
+      (e) => e.type === 'stun' && e.duration > 0 && Math.random() < STATUS_STUN_SKIP_CHANCE
+    );
+  }
+
+  /**
+   * Applies poison/burn damage and decrements all effect durations by 1.
+   * Effects that reach 0 duration are removed.
+   * Returns the total tick damage applied (for callers that need to track HP changes).
+   */
+  function processStatusTick(entity: { currHealth?: number; health?: number; statusEffects?: StatusEffect[] }): number {
+    if (!entity.statusEffects || entity.statusEffects.length === 0) return 0;
+    let tickDamage = 0;
+    entity.statusEffects = entity.statusEffects
+      .map((e) => ({ ...e, duration: e.duration - 1 }))
+      .filter((e) => e.duration >= 0);
+    for (const e of entity.statusEffects) {
+      if ((e.type === 'poison' || e.type === 'burn') && entity.health !== undefined && entity.currHealth !== undefined) {
+        const dmg = Math.ceil((entity.health * e.magnitude) / 100);
+        tickDamage += dmg;
+        entity.currHealth = Math.max(0, entity.currHealth - dmg);
+      }
+    }
+    return tickDamage;
+  }
+
+  /**
+   * Returns the total damage multiplier from armorBreak effects active on the target.
+   * If no armor break is present returns 1 (no change). Stacks additively across sources.
+   */
+  function armorBreakMultiplier(target: { statusEffects?: StatusEffect[] }): number {
+    if (!target.statusEffects) return 1;
+    const totalBreak = target.statusEffects
+      .filter((e) => e.type === 'armorBreak' && e.duration > 0)
+      .reduce((sum, e) => sum + e.magnitude, 0);
+    return 1 + totalBreak * STATUS_ARMOR_BREAK_MULTIPLIER;
+  }
+
+  /**
+   * Determines whether a hero should consume a health potion this turn.
+   *
+   * Triggers when the hero's current HP has fallen below HERO_AUTO_HEAL_THRESHOLD
+   * of their max HP (default 50%), the hero actually has that potion, and the
+   * global potion stock has an entry for it.
+   *
+   * Centralising this condition makes it easy to:
+   *  - tune the threshold (change HERO_AUTO_HEAL_THRESHOLD in gameConstants)
+   *  - unit-test potion behaviour in isolation
+   *  - extend with per-hero override thresholds in the future
+   */
+  function shouldUsePotion(hero: Hero, potionSlot: number, potionDefs: Array<{ value?: number }>): boolean {
+    if (!hero.equip.potions[potionSlot] || hero.equip.potions[potionSlot].count <= 0) return false;
+    if (!potionDefs[potionSlot]) return false;
+    return hero.currHealth < hero.health * HERO_AUTO_HEAL_THRESHOLD;
+  }
+
+  // ─── End Status Effect Helpers ─────────────────────────────────────────
+
   function heroTurn(heroL: Hero[], enemyL: Monster[]): Monster[] {
     const potions = store.getState().production.potions as Array<{ value?: number }>;
     let damage = 0;
+
+    // Process per-hero status ticks (poison/burn) and accumulate damage from living, non-stunned heroes.
     for (let i = 0; i < heroL.length; i++) {
       if (heroL[i].currHealth > 0) {
+        processStatusTick(heroL[i]);
+        if (heroL[i].currHealth <= 0) continue; // died from status tick
+        if (isStunned(heroL[i])) continue;       // stunned: skip this hero's attack
         if (heroL[i].equip.potions[POTION_REGEN].active) {
           const regenVal = potions[POTION_REGEN] ? (potions[POTION_REGEN].value ?? 0) : 0;
           const healPct = Math.floor((heroL[i].health / 100) * regenVal);
@@ -149,17 +224,26 @@ function CombatServiceFactory(
         damage += heroDamage(heroL[i]);
       }
     }
+
+    // Distribute cumulative hero damage sequentially through enemies.
+    // armorBreakMultiplier is applied per-enemy target so a broken-armored enemy
+    // takes proportionally more damage from the hero's share.
     const tempDead: Monster[] = [];
     for (let i = 0; i < enemyL.length; i++) {
       if (enemyL[i].health === 0) {
         // already dead
-      } else if (enemyL[i].health < damage) {
-        enemyL[i].health = 0;
-        tempDead.push(enemyL[i]);
-        damage = 0;
       } else {
-        enemyL[i].health -= damage;
-        damage = 0;
+        // Process monster status ticks (poison etc.) at the start of its "receive damage" step.
+        processStatusTick(enemyL[i]);
+        const effectiveDamage = Math.ceil(damage * armorBreakMultiplier(enemyL[i]));
+        if (enemyL[i].health <= effectiveDamage) {
+          enemyL[i].health = 0;
+          tempDead.push(enemyL[i]);
+          damage = 0;
+        } else {
+          enemyL[i].health -= effectiveDamage;
+          damage = 0;
+        }
       }
     }
     return tempDead;
@@ -169,7 +253,8 @@ function CombatServiceFactory(
     const potions = store.getState().production.potions as Array<{ value?: number }>;
     let turnDamage = 0;
     for (let i = 0; i < monsterList.length; i++) {
-      if (monsterList[i].health > 0) {
+      // Stunned monsters skip their attack for this turn.
+      if (monsterList[i].health > 0 && !isStunned(monsterList[i])) {
         turnDamage += enemyDamage(monsterList[i]);
       }
     }
@@ -189,28 +274,15 @@ function CombatServiceFactory(
           heroDamageAmount++;
         }
         hero[k].currHealth -= heroDamageAmount;
-        if (
-          hero[k].equip.potions[POTION_GREAT_HEALTH] &&
-          hero[k].equip.potions[POTION_GREAT_HEALTH].count > 0 &&
-          potions[POTION_GREAT_HEALTH] &&
-          hero[k].health - hero[k].currHealth > (potions[POTION_GREAT_HEALTH].value ?? 0)
-        ) {
+        // Try best available health potion first (great → good → basic).
+        // shouldUsePotion triggers when HP drops below HERO_AUTO_HEAL_THRESHOLD.
+        if (shouldUsePotion(hero[k], POTION_GREAT_HEALTH, potions)) {
           hero[k].equip.potions[POTION_GREAT_HEALTH].count--;
           hero[k].currHealth = Math.min(hero[k].health, hero[k].currHealth + (potions[POTION_GREAT_HEALTH].value ?? 0));
-        } else if (
-          hero[k].equip.potions[POTION_GOOD_HEALTH] &&
-          hero[k].equip.potions[POTION_GOOD_HEALTH].count > 0 &&
-          potions[POTION_GOOD_HEALTH] &&
-          hero[k].health - hero[k].currHealth > (potions[POTION_GOOD_HEALTH].value ?? 0)
-        ) {
+        } else if (shouldUsePotion(hero[k], POTION_GOOD_HEALTH, potions)) {
           hero[k].equip.potions[POTION_GOOD_HEALTH].count--;
           hero[k].currHealth = Math.min(hero[k].health, hero[k].currHealth + (potions[POTION_GOOD_HEALTH].value ?? 0));
-        } else if (
-          hero[k].equip.potions[POTION_HEALTH] &&
-          hero[k].equip.potions[POTION_HEALTH].count > 0 &&
-          potions[POTION_HEALTH] &&
-          hero[k].health - hero[k].currHealth > (potions[POTION_HEALTH].value ?? 0)
-        ) {
+        } else if (shouldUsePotion(hero[k], POTION_HEALTH, potions)) {
           hero[k].equip.potions[POTION_HEALTH].count--;
           hero[k].currHealth = Math.min(hero[k].health, hero[k].currHealth + (potions[POTION_HEALTH].value ?? 0));
         }
@@ -254,10 +326,13 @@ function CombatServiceFactory(
           if (hero[i].level <= journey.dungeon.level * 2) {
             battle.experience += monstersList[j].value * MONSTER_XP_MULTIPLIER;
           }
-          const lootChance = Math.random() * 100;
-          if (lootChance < 10 && monstersList[j].high != null) {
-            addLoot(monstersList[j].high, hero[i]);
-          }
+        }
+        // Loot is assigned once per monster and given to one hero (round-robin).
+        // This prevents party size from multiplying gold/scrap rewards.
+        const lootChance = Math.random() * 100;
+        if (lootChance < 10 && monstersList[j].high != null) {
+          const lootRecipient = hero[j % hero.length];
+          addLoot(monstersList[j].high, lootRecipient);
         }
       }
       if (battle.boss) {

--- a/src/services/dungeon.service.ts
+++ b/src/services/dungeon.service.ts
@@ -163,6 +163,26 @@ function DungeonServiceFactory(store: AppStore, $timeout: (fn: () => void, ms: n
     }
   }
 
+  /**
+   * Returns the enemy stat multiplier for the given party size.
+   *
+   * Old behaviour: flat MULTI_HERO_SCALE_FACTOR (10) for any party > 1, regardless of size.
+   * New behaviour: scales linearly — each additional hero beyond the first adds
+   *   (MULTI_HERO_SCALE_FACTOR - 1) to the multiplier.
+   *
+   *   partySize=1 → 1×  (solo, no scaling)
+   *   partySize=2 → 10× (same as before for 2-hero parties)
+   *   partySize=3 → 19×
+   *   partySize=4 → 28×
+   *
+   * Adjust MULTI_HERO_SCALE_FACTOR in gameConstants to tune how steeply enemy
+   * strength grows with party size.
+   */
+  function partyScaleFactor(partySize: number): number {
+    if (partySize <= 1) return 1;
+    return 1 + (partySize - 1) * (MULTI_HERO_SCALE_FACTOR - 1);
+  }
+
   function monsterFight(journey: Journey): void {
     const s = getFlatState(store);
     const eLevel = journey.dungeon.encounterLevel;
@@ -191,7 +211,7 @@ function DungeonServiceFactory(store: AppStore, $timeout: (fn: () => void, ms: n
         }
       }
       const currentMonster = Math.floor(Math.random() * reducedMonster.length);
-      const multi = journey.hero.length > 1 ? MULTI_HERO_SCALE_FACTOR : 1;
+      const multi = partyScaleFactor(journey.hero.length);
       encounterMonsters.push({
         id: encounterMonsters.length,
         name: reducedMonster[currentMonster].name,
@@ -212,7 +232,7 @@ function DungeonServiceFactory(store: AppStore, $timeout: (fn: () => void, ms: n
   function bossFight(journey: Journey): void {
     const s = getFlatState(store);
     const bossID = journey.dungeon.bossID;
-    const multi = journey.hero.length > 1 ? MULTI_HERO_SCALE_FACTOR : 1;
+    const multi = partyScaleFactor(journey.hero.length);
     const bossBattle: Monster[] = [
       {
         id: 0,

--- a/src/services/hero.service.ts
+++ b/src/services/hero.service.ts
@@ -10,6 +10,7 @@ import {
   HERO_HEALTH_PER_LEVEL,
   HERO_XP_PER_LEVEL,
   HERO_REST_HEAL_PERCENT,
+  HERO_AUTO_HEAL_THRESHOLD,
   WEAPON_DURABILITY_LOW_THRESHOLD,
   BUILDING_BLACKSMITH,
   BUILDING_TAVERN,
@@ -235,7 +236,9 @@ function HeroServiceFactory(
           s.weapons[weapon.id].count--;
           hero.equip.weapon = structuredClone(s.weapons[weapon.id]);
         }
-        for (let k = 0; k < hero.equip.potions.length; k++) {
+        // Buy potions — iterate highest-tier first so gold is spent on the most valuable
+        // potions when the hero can't afford to fill every slot.
+        for (let k = hero.equip.potions.length - 1; k >= 0; k--) {
           const potionK = s.potions[k] as FlatGameState['potions'][number] & { maxHero?: number };
           if (
             potionK &&
@@ -249,8 +252,9 @@ function HeroServiceFactory(
             hero.equip.potions[k].count++;
           }
         }
+        // Use a basic healing potion at rest when HP is below HERO_AUTO_HEAL_THRESHOLD.
         if (
-          hero.health - hero.currHealth >= (s.potion.healing ?? 0) &&
+          hero.currHealth < hero.health * HERO_AUTO_HEAL_THRESHOLD &&
           s.potion.count > 0 &&
           s.gold + s.potion.sellPrice <= s.maxGold &&
           hero.equip.gold >= s.potion.sellPrice
@@ -272,7 +276,7 @@ function HeroServiceFactory(
         DungeonService.attemptDungeon(hero.dungeon, [hero]);
         hero.location = s.dungeons[hero.dungeon].name;
       } else if (hero.progress === 'Idle') {
-        EconomyService.incrRes(Math.ceil(s.heroList[i].level / 4) ^ 2);
+        EconomyService.incrRes(Math.ceil(s.heroList[i].level / 4) ** 2);
       }
     }
     dispatchHeroes(store, s);
@@ -287,8 +291,14 @@ function HeroServiceFactory(
         case 0:
           break;
         case 1: {
-          if (s.potion.count + s.potion.working < s.potion.maxCount && hero.progress === 'Idle') {
+          // craftStarted prevents a hero from starting more than one craft per tick.
+          // hero.progress is read from the flat snapshot so it doesn't reflect the
+          // async ProductionService dispatch; without this guard, a hero with multiple
+          // available slots would queue several crafts in the same game tick.
+          let craftStarted = false;
+          if (!craftStarted && s.potion.count + s.potion.working < s.potion.maxCount && hero.progress === 'Idle') {
             if (EconomyService.decResources(s.potion.cost)) {
+              craftStarted = true;
               s.potion.working++;
               if (hero.academy.id !== HERO_CLASSES[1].id) {
                 ProductionService.createPotion(
@@ -308,11 +318,13 @@ function HeroServiceFactory(
           }
           for (let j = 0; j < s.potions.length; j++) {
             if (
+              !craftStarted &&
               s.potions[j].enabled &&
               s.potions[j].count + s.potions[j].working < s.potions[j].maxCount &&
               hero.progress === 'Idle'
             ) {
               if (EconomyService.decResources(s.potions[j].cost)) {
+                craftStarted = true;
                 s.potions[j].working++;
                 if (hero.academy.id !== HERO_CLASSES[1].id) {
                   ProductionService.createPotions(
@@ -336,13 +348,16 @@ function HeroServiceFactory(
           break;
         }
         case 2: {
+          let craftStarted = false;
           for (let j = 0; j < s.weapons.length; j++) {
             if (
+              !craftStarted &&
               s.weapons[j].enabled &&
               s.weapons[j].count + s.weapons[j].working < s.weapons[j].maxCount &&
               hero.progress === 'Idle'
             ) {
               if (EconomyService.decResources(s.weapons[j].cost)) {
+                craftStarted = true;
                 s.weapons[j].working++;
                 const wProdTime = (s.weapons[j] as { prodTime?: number }).prodTime ?? 0;
                 if (hero.academy.id !== HERO_CLASSES[1].id) {

--- a/src/services/hero.service.ts
+++ b/src/services/hero.service.ts
@@ -296,7 +296,7 @@ function HeroServiceFactory(
           // async ProductionService dispatch; without this guard, a hero with multiple
           // available slots would queue several crafts in the same game tick.
           let craftStarted = false;
-          if (!craftStarted && s.potion.count + s.potion.working < s.potion.maxCount && hero.progress === 'Idle') {
+          if (s.potion.count + s.potion.working < s.potion.maxCount && hero.progress === 'Idle') {
             if (EconomyService.decResources(s.potion.cost)) {
               craftStarted = true;
               s.potion.working++;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,7 +121,7 @@ export interface StatusEffect {
   type: StatusEffectType;
   /** Turns remaining before the effect expires. */
   duration: number;
-  /** Poison/burn: flat damage per turn. armorBreak: % damage multiplier increase (0–1). stun: unused. */
+  /** Poison/burn: percent of max HP dealt as damage per turn (0–100). armorBreak: % damage multiplier increase (0–1). stun: unused. */
   magnitude: number;
   /** ID of the hero or monster that applied the effect, for tracking purposes. */
   sourceId?: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,8 @@ export interface Hero {
   academy: HeroClass;
   party: boolean;
   autoAdventure?: boolean;
+  /** Active status effects on this hero (optional; absent = no effects). */
+  statusEffects?: StatusEffect[];
 }
 
 // ─── Building ─────────────────────────────────────────────────────────────
@@ -111,6 +113,20 @@ export interface Blueprint {
   working?: number;
 }
 
+// ─── Status Effects ───────────────────────────────────────────────────────
+
+export type StatusEffectType = 'stun' | 'poison' | 'armorBreak' | 'burn';
+
+export interface StatusEffect {
+  type: StatusEffectType;
+  /** Turns remaining before the effect expires. */
+  duration: number;
+  /** Poison/burn: flat damage per turn. armorBreak: % damage multiplier increase (0–1). stun: unused. */
+  magnitude: number;
+  /** ID of the hero or monster that applied the effect, for tracking purposes. */
+  sourceId?: number;
+}
+
 // ─── Dungeon / Monster ────────────────────────────────────────────────────
 
 export interface Monster {
@@ -126,6 +142,8 @@ export interface Monster {
   xp?: number;
   low?: string;
   high?: string;
+  /** Active status effects on this monster (optional; absent = no effects). */
+  statusEffects?: StatusEffect[];
 }
 
 export interface Dungeon {


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive status effects system (stun, poison, burn, armor break) to the combat service, refactors potion usage logic, improves party scaling, and fixes several bugs in hero and dungeon services.

## Key Changes

### Status Effects System
- Added `StatusEffect` type and interface to support stun, poison, burn, and armor break effects
- Implemented helper functions in combat service:
  - `isStunned()`: checks if entity has active stun and applies probabilistic skip chance
  - `processStatusTick()`: applies poison/burn damage each turn and decrements effect durations
  - `armorBreakMultiplier()`: calculates cumulative damage multiplier from armor break effects
- Added status effect constants: `STATUS_POISON_TICK_PERCENT`, `STATUS_STUN_SKIP_CHANCE`, `STATUS_ARMOR_BREAK_MULTIPLIER`

### Combat Improvements
- Integrated status effect processing into hero and monster turns
- Stunned entities now skip their attacks
- Armor break effects increase incoming damage multiplicatively
- Refactored potion usage logic into `shouldUsePotion()` helper function
  - Centralizes healing threshold logic using new `HERO_AUTO_HEAL_THRESHOLD` constant (50%)
  - Simplifies repeated potion availability checks
- Fixed loot distribution: loot is now assigned once per monster to a round-robin hero, preventing party size from multiplying rewards
- Fixed off-by-one error in `clearPotions()` loop (was starting at index 1, now starts at 0)

### Party Scaling
- Introduced `partyScaleFactor()` function in dungeon service
- Changed from flat 10× multiplier for any party > 1 to linear scaling: `1 + (partySize - 1) * 9`
  - Solo: 1×, 2-hero: 10×, 3-hero: 19×, 4-hero: 28×
- Applied to both monster and boss encounters

### Hero Service Fixes
- Fixed potion purchase order: now iterates highest-tier potions first so limited gold is spent on best potions
- Fixed healing potion usage at rest: now uses `HERO_AUTO_HEAL_THRESHOLD` instead of checking if damage exceeds potion value
- Fixed resource increment calculation: changed `^` (XOR) to `**` (exponentiation) operator
- Added `craftStarted` guard to prevent heroes from queuing multiple crafts in a single game tick

### Type System
- Added optional `statusEffects` field to `Hero` and `Monster` interfaces
- Exported `StatusEffect` type from types module

https://claude.ai/code/session_013SsQqBnXKgd6wHKZtmPnhT